### PR TITLE
Restore pack.mcmeta

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "Soulbound Block Mod"
+  }
+}


### PR DESCRIPTION
## Summary
- recreate the missing `pack.mcmeta` file so textures and language files load correctly

## Testing
- `./gradlew build` *(fails: No such file or directory)*
