### PR TITLE
Add server usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Este es mi mod de Minecraft creado en Forge 1.20.1. Añade el bloque "Soulbound 
 
 - Java 17
 - Gradle 7.6
+- Servidor de Minecraft 1.20.1 con Forge 47.2.0
 
 ## ¿Cómo clonar el repositorio?
 
@@ -31,3 +32,15 @@ El artefacto final se genera en `build/libs/`. Copia el `.jar` resultante al dir
 ## Pruebas rápidas en el DevContainer
 
 Para realizar pruebas locales rápidas, usa el DevContainer: compila con el comando anterior y luego prueba el jar en un entorno de servidor local o cliente que tenga Forge 1.20.1.
+
+## Uso en servidor propio
+
+Este mod requiere un servidor de Minecraft 1.20.1 con Forge 47.2.0 y Java 17.
+
+1. Descarga la versión del servidor de Forge para 1.20.1 (por ejemplo `forge-1.20.1-47.2.0`).
+2. Copia el `.jar` generado en `build/libs/` dentro de la carpeta `mods/` del servidor.
+3. Inicia el servidor con:
+
+```bash
+java -jar forge-1.20.1-47.2.0.jar nogui
+```


### PR DESCRIPTION
## Summary
- document the required server and Java versions
- add instructions for using the mod on your own server

## Testing
- `gradle test --no-daemon` *(fails: ForgeGradle doesn't support Gradle 8)*
