### PR TITLE
Add dist output handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gradle/
 build/
 out/
+dist/
 
 # IntelliJ
 .idea/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Dentro del contenedor ejecuta:
 ./gradlew build
 ```
 
-El artefacto final se genera en `build/libs/`. Copia el `.jar` resultante al directorio `mods` de tu servidor de Minecraft.
+El artefacto final se genera en `dist/`. Copia el `.jar` resultante al directorio `mods` de tu servidor de Minecraft.
 
 ## Pruebas rápidas en el DevContainer
 
@@ -38,7 +38,7 @@ Para realizar pruebas locales rápidas, usa el DevContainer: compila con el coma
 Este mod requiere un servidor de Minecraft 1.20.1 con Forge 47.2.0 y Java 17.
 
 1. Descarga la versión del servidor de Forge para 1.20.1 (por ejemplo `forge-1.20.1-47.2.0`).
-2. Copia el `.jar` generado en `build/libs/` dentro de la carpeta `mods/` del servidor.
+2. Copia el `.jar` generado en `dist/` dentro de la carpeta `mods/` del servidor.
 3. Inicia el servidor con:
 
 ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -30,3 +30,14 @@ tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.release = 17
 }
+
+// Copiar el JAR generado a la carpeta dist/
+task copyToDist(type: Copy) {
+    from("${buildDir}/libs")
+    into("${rootDir}/dist")
+    include('*.jar')
+}
+
+// Ejecutar copyToDist cuando finalice la tarea build
+build.finalizedBy(copyToDist)
+


### PR DESCRIPTION
## Summary

- Configured Gradle to place the generated JAR in a new “dist/” directory after building, ensuring the mod outputs are easy to locate
- Added “dist/” to the .gitignore file so that build artifacts are excluded from version control
- Updated the README so build instructions reference the “dist/” directory as the destination for compiled JAR files
