### PR TITLE
Add Spanish Javadoc for soulbound block

### DIFF
--- a/src/main/java/com/banzaicode/soulboundblock/SoulboundBlockMod.java
+++ b/src/main/java/com/banzaicode/soulboundblock/SoulboundBlockMod.java
@@ -7,10 +7,18 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
+/**
+ * Clase principal del mod que inicializa el registro de los elementos del
+ * bloque "soulbound".
+ */
 @Mod(SoulboundBlockMod.MOD_ID)
 public class SoulboundBlockMod {
     public static final String MOD_ID = "soulboundblock";
 
+    /**
+     * Constructor donde se registran los bloques, ítems y entidades de bloque
+     * asociados al mod.
+     */
     public SoulboundBlockMod() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 

--- a/src/main/java/com/banzaicode/soulboundblock/block/BlockEntitySoulbound.java
+++ b/src/main/java/com/banzaicode/soulboundblock/block/BlockEntitySoulbound.java
@@ -8,23 +8,39 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.UUID;
 
+/**
+ * Entidad de bloque que almacena el UUID del jugador que colocó el bloque
+ * soulbound.
+ */
 public class BlockEntitySoulbound extends BlockEntity {
 
     private UUID owner;
 
+    /**
+     * Crea una nueva instancia asociada al tipo de entidad registrado.
+     */
     public BlockEntitySoulbound(BlockPos pos, BlockState state) {
         super(ModBlockEntities.SOULBOUND_BLOCK_ENTITY.get(), pos, state);
     }
 
+    /**
+     * Obtiene el UUID del dueño del bloque.
+     */
     public UUID getOwner() {
         return owner;
     }
 
+    /**
+     * Establece el dueño del bloque y marca la entidad como modificada.
+     */
     public void setOwner(UUID owner) {
         this.owner = owner;
         setChanged();
     }
 
+    /**
+     * Guarda el UUID del dueño en el NBT para persistirlo.
+     */
     @Override
     protected void saveAdditional(CompoundTag tag) {
         super.saveAdditional(tag);
@@ -33,6 +49,9 @@ public class BlockEntitySoulbound extends BlockEntity {
         }
     }
 
+    /**
+     * Carga el UUID del dueño desde el NBT al aparecer el bloque en el mundo.
+     */
     @Override
     public void load(CompoundTag tag) {
         super.load(tag);

--- a/src/main/java/com/banzaicode/soulboundblock/block/BlockSoulbound.java
+++ b/src/main/java/com/banzaicode/soulboundblock/block/BlockSoulbound.java
@@ -16,12 +16,23 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 
 import java.util.UUID;
 
+/**
+ * Bloque que queda "vinculado" al alma del jugador que lo coloca. Solo su dueño
+ * podrá romperlo posteriormente.
+ */
 public class BlockSoulbound extends Block {
 
+    /**
+     * Constructor que simplemente delega la configuración del bloque.
+     */
     public BlockSoulbound(Properties properties) {
         super(properties);
     }
 
+    /**
+     * Cuando se coloca el bloque se almacena el UUID del jugador más cercano
+     * para dejarlo como dueño.
+     */
     @Override
     public void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving) {
         super.onPlace(state, level, pos, oldState, isMoving);
@@ -40,6 +51,10 @@ public class BlockSoulbound extends Block {
         }
     }
 
+    /**
+     * Evita que un jugador distinto al dueño destruya el bloque. Si no es el
+     * dueño se cancela la destrucción y se muestra un mensaje.
+     */
     @Override
     public void playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player) {
         if (!level.isClientSide) {
@@ -58,11 +73,18 @@ public class BlockSoulbound extends Block {
         super.playerWillDestroy(level, pos, state, player);
     }
 
+    /**
+     * Indica que el bloque tiene una entidad asociada para guardar datos.
+     */
     @Override
     public boolean hasBlockEntity(BlockState state) {
         return true;
     }
 
+    /**
+     * Crea una instancia de la entidad de bloque encargada de almacenar el
+     * propietario.
+     */
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new BlockEntitySoulbound(pos, state);

--- a/src/main/java/com/banzaicode/soulboundblock/registry/ModBlockEntities.java
+++ b/src/main/java/com/banzaicode/soulboundblock/registry/ModBlockEntities.java
@@ -9,6 +9,9 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+/**
+ * Registro de las entidades de bloque utilizadas para el bloque soulbound.
+ */
 public class ModBlockEntities {
 
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITIES =
@@ -21,6 +24,9 @@ public class ModBlockEntities {
                             ModBlocks.SOULBOUND_BLOCK.get()
                     ).build(null));
 
+    /**
+     * Registra las entidades de bloque en el bus de eventos de Forge.
+     */
     public static void register(IEventBus eventBus) {
         BLOCK_ENTITIES.register(eventBus);
     }

--- a/src/main/java/com/banzaicode/soulboundblock/registry/ModBlocks.java
+++ b/src/main/java/com/banzaicode/soulboundblock/registry/ModBlocks.java
@@ -12,17 +12,27 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
+/**
+ * Contiene y registra los bloques personalizados del mod.
+ */
 public class ModBlocks {
 
+    /** Registro diferido para todos los bloques del mod. */
     public static final DeferredRegister<Block> BLOCKS =
             DeferredRegister.create(ForgeRegistries.BLOCKS, SoulboundBlockMod.MOD_ID);
 
+    /**
+     * Bloque principal que queda ligado al jugador que lo coloca.
+     */
     public static final RegistryObject<Block> SOULBOUND_BLOCK =
             BLOCKS.register("soulbound_block",
                     () -> new BlockSoulbound(BlockBehaviour.Properties.of(Material.METAL)
                             .strength(50f, 1200f)
                             .requiresCorrectToolForDrops()));
 
+    /**
+     * Registra los bloques en el bus de eventos de Forge.
+     */
     public static void register(IEventBus eventBus) {
         BLOCKS.register(eventBus);
     }

--- a/src/main/java/com/banzaicode/soulboundblock/registry/ModItems.java
+++ b/src/main/java/com/banzaicode/soulboundblock/registry/ModItems.java
@@ -13,19 +13,32 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
 @Mod.EventBusSubscriber(modid = SoulboundBlockMod.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+/**
+ * Registro y manejo de los ítems del mod, incluido el bloque soulbound como ítem.
+ */
 public class ModItems {
 
+    /** Registro diferido para todos los ítems del mod. */
     public static final DeferredRegister<Item> ITEMS =
             DeferredRegister.create(ForgeRegistries.ITEMS, SoulboundBlockMod.MOD_ID);
 
+    /**
+     * Ítem correspondiente al bloque soulbound, necesario para poder colocarlo en el mundo.
+     */
     public static final RegistryObject<Item> SOULBOUND_BLOCK_ITEM =
             ITEMS.register("soulbound_block",
                     () -> new BlockItem(ModBlocks.SOULBOUND_BLOCK.get(), new Item.Properties()));
 
+    /**
+     * Registra los ítems en el bus de eventos de Forge.
+     */
     public static void register(IEventBus eventBus) {
         ITEMS.register(eventBus);
     }
 
+    /**
+     * Añade el ítem a la pestaña de bloques de construcción en el modo creativo.
+     */
     @SubscribeEvent
     public static void onCreativeTabBuild(CreativeModeTabEvent.BuildContents event) {
         if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {


### PR DESCRIPTION
## Summary

- Added a descriptive header to the mod’s main class, explaining it registers the soulbound block elements and detailing its constructor’s purpose
- Documented how the soulbound block records its owner when placed and prevents destruction by other players, with notes on creating its block entity
- Explained the block entity’s role in storing the player UUID and persisting it via NBT data
- Clarified the registry classes for block entities, blocks, and items, emphasizing their integration with the soulbound mechanic
