### PR TITLE
Update project to Forge 58.0.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Minecraft Forge Modding 1.20.1",
+  "name": "Minecraft Forge Modding 1.21.8",
   "build": {
     "dockerfile": "Dockerfile"
   },

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Soulbound Block Mod
 
-Este es mi mod de Minecraft creado en Forge 1.20.1. Añade el bloque "Soulbound Block", el cual solo puede ser destruido por quien lo colocó.
+Este es mi mod de Minecraft creado en Forge 1.21.8. Añade el bloque "Soulbound Block", el cual solo puede ser destruido por quien lo colocó.
 Para más detalles sobre el entorno y la compilación revisa la [guía completa](docs/README.md).
 
 ## Requisitos
 
-- Java 17
+- Java 21
 - Gradle 7.6
-- Servidor de Minecraft 1.20.1 con Forge 47.2.0
+- Servidor de Minecraft 1.21.8 con Forge 58.0.0
 
 ## ¿Cómo clonar el repositorio?
 
@@ -18,7 +18,7 @@ cd banzaicode-soulbound-block
 
 ## Abrir en VS Code con DevContainer
 
-Con VS Code instalado, abre la carpeta del repositorio y selecciona **Reopen in Container** para iniciar el DevContainer provisto. Allí ya tendrás Java 17 y Gradle configurados.
+Con VS Code instalado, abre la carpeta del repositorio y selecciona **Reopen in Container** para iniciar el DevContainer provisto. Allí ya tendrás Java 21 y Gradle configurados.
 
 ## Compilar el mod
 
@@ -32,23 +32,23 @@ El artefacto final se genera en `dist/`. Copia el `.jar` resultante al directori
 
 ## Pruebas rápidas en el DevContainer
 
-Para realizar pruebas locales rápidas, usa el DevContainer: compila con el comando anterior y luego prueba el jar en un entorno de servidor local o cliente que tenga Forge 1.20.1.
+Para realizar pruebas locales rápidas, usa el DevContainer: compila con el comando anterior y luego prueba el jar en un entorno de servidor local o cliente que tenga Forge 1.21.8.
 
 ## Uso en servidor propio
 
-Este mod requiere un servidor de Minecraft 1.20.1 con Forge 47.2.0 y Java 17.
+Este mod requiere un servidor de Minecraft 1.21.8 con Forge 58.0.0 y Java 21.
 
-1. Descarga la versión del servidor de Forge para 1.20.1 (por ejemplo `forge-1.20.1-47.2.0`).
+1. Descarga la versión del servidor de Forge para 1.21.8 (por ejemplo `forge-1.21.8-58.0.0`).
 2. Copia el `.jar` generado en `dist/` dentro de la carpeta `mods/` del servidor.
 3. Inicia el servidor con:
 
 ```bash
-java -jar forge-1.20.1-47.2.0.jar nogui
+java -jar forge-1.21.8-58.0.0.jar nogui
 ```
 
 ## Solución de problemas
 
-- **Versión incorrecta de Forge**: asegúrate de usar la versión 1.20.1 de Forge (47.2.0). Si utilizas otra versión el mod puede no cargar. Descarga la versión adecuada desde el sitio oficial de Forge e instálala nuevamente.
-- **No estás usando Java 17**: la compilación y ejecución requieren Java 17. Instala JDK 17 o abre el proyecto en el DevContainer donde ya está incluido.
+- **Versión incorrecta de Forge**: asegúrate de usar la versión 1.21.8 de Forge (58.0.0). Si utilizas otra versión el mod puede no cargar. Descarga la versión adecuada desde el sitio oficial de Forge e instálala nuevamente.
+- **No estás usando Java 21**: la compilación y ejecución requieren Java 21. Instala JDK 21 o abre el proyecto en el DevContainer donde ya está incluido.
 - **Gradle ejecutado fuera del DevContainer**: si corres `./gradlew` fuera del contenedor puedes tener dependencias faltantes o la versión de Java incorrecta. Abre el repositorio con **Reopen in Container** y ejecuta los comandos allí.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id 'net.minecraftforge.gradle' version '5.1.+'
+    id 'net.minecraftforge.gradle' version '6.+'
 }
 group = 'com.banzaicode'
 version = '1.0.0'
 archivesBaseName = 'soulboundblock'
-java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 minecraft {
-    mappings channel: 'official', version: '1.20.1'
+    mappings channel: 'official', version: '1.21.8'
     runs {
         client {
             workingDirectory project.file('run')
@@ -24,11 +24,11 @@ repositories {
     maven { url = 'https://maven.minecraftforge.net/' }
 }
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.20.1-47.2.0'
+    minecraft 'net.minecraftforge:forge:1.21.8-58.0.0'
 }
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
-    options.release = 17
+    options.release = 21
 }
 
 // Copiar el JAR generado a la carpeta dist/

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Esta sección del tutorial explica cómo configurar el entorno, compilar el mod 
 
 1. Instala [Visual Studio Code](https://code.visualstudio.com/).
 2. Abre este repositorio en VS Code y elige **Reopen in Container**.
-3. El contenedor se construirá con Java 17 y Gradle listos para usar.
+3. El contenedor se construirá con Java 21 y Gradle listos para usar.
 
 Cuando el contenedor esté listo verás la carpeta del proyecto abierta con todas las dependencias resueltas.
 
@@ -22,7 +22,7 @@ Al finalizar se generará un archivo `.jar` en la carpeta `dist/`. Este es el mo
 
 ## 3. Instalar en Minecraft
 
-1. Descarga e instala Forge 1.20.1 en tu cliente o servidor.
+1. Descarga e instala Forge 1.21.8 en tu cliente o servidor.
 2. Copia el `.jar` que está en `dist/` dentro de la carpeta `mods/` de tu instalación de Minecraft.
 3. Inicia el juego o el servidor y el bloque **Soulbound** estará disponible.
 

--- a/src/main/java/com/banzaicode/soulboundblock/block/BlockSoulbound.java
+++ b/src/main/java/com/banzaicode/soulboundblock/block/BlockSoulbound.java
@@ -11,7 +11,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.level.material.Material;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 
 import java.util.UUID;

--- a/src/main/java/com/banzaicode/soulboundblock/registry/ModBlocks.java
+++ b/src/main/java/com/banzaicode/soulboundblock/registry/ModBlocks.java
@@ -6,7 +6,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.material.Material;
+import net.minecraft.world.level.material.MapColor;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -26,7 +26,8 @@ public class ModBlocks {
      */
     public static final RegistryObject<Block> SOULBOUND_BLOCK =
             BLOCKS.register("soulbound_block",
-                    () -> new BlockSoulbound(BlockBehaviour.Properties.of(Material.METAL)
+                    () -> new BlockSoulbound(BlockBehaviour.Properties.of()
+                            .mapColor(MapColor.METAL)
                             .strength(50f, 1200f)
                             .requiresCorrectToolForDrops()));
 

--- a/src/main/java/com/banzaicode/soulboundblock/registry/ModItems.java
+++ b/src/main/java/com/banzaicode/soulboundblock/registry/ModItems.java
@@ -4,7 +4,7 @@ import com.banzaicode.soulboundblock.SoulboundBlockMod;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
-import net.minecraftforge.event.CreativeModeTabEvent;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -40,7 +40,7 @@ public class ModItems {
      * Añade el ítem a la pestaña de bloques de construcción en el modo creativo.
      */
     @SubscribeEvent
-    public static void onCreativeTabBuild(CreativeModeTabEvent.BuildContents event) {
+    public static void onCreativeTabBuild(BuildCreativeModeTabContentsEvent event) {
         if (event.getTabKey() == CreativeModeTabs.BUILDING_BLOCKS) {
             event.accept(SOULBOUND_BLOCK_ITEM);
         }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[47,)"
+loaderVersion="[58,)"
 license="MIT"
 [[mods]]
 modId="soulboundblock"


### PR DESCRIPTION
## Summary
- update Forge and mappings for Minecraft 1.21.8
- bump java version
- update loader requirement and devcontainer config
- refresh docs for Forge 58
- attempt code changes for newer Forge API

## Testing
- `gradle build` *(fails: package net.minecraftforge.eventbus.api does not exist)*
