### PR TITLE
Configure Git in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,5 +18,10 @@
     "vscjava.vscode-gradle",
     "redhat.java"
   ],
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
+  ],
+  "postCreateCommand": "git config --get user.name >/dev/null || git config --global user.name \"Tu Nombre\" && git config --global user.email \"tu@ejemplo.com\"",
   "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,6 @@
     "source=${localEnv:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
   ],
-  "postCreateCommand": "git config --get user.name >/dev/null || git config --global user.name \"Tu Nombre\" && git config --global user.email \"tu@ejemplo.com\"",
+  "postCreateCommand": "git config --get user.name >/dev/null || git config --global user.name \"RockBanzai\" && git config --global user.email \"hrocca76@gmail.com\"",
   "remoteUser": "root"
 }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ cd banzaicode-soulbound-block
 
 Con VS Code instalado, abre la carpeta del repositorio y selecciona **Reopen in Container** para iniciar el DevContainer provisto. Allí ya tendrás Java 21 y Gradle configurados.
 
+## Compartir configuración de Git
+
+El contenedor monta de forma opcional tu archivo `~/.gitconfig` y la carpeta `~/.ssh` para reutilizar tu configuración personal. Si no tienes un usuario configurado, se aplicarán por defecto `Tu Nombre` y `tu@ejemplo.com` al crear el contenedor.
+
 ## Compilar el mod
 
 Dentro del contenedor ejecuta:


### PR DESCRIPTION
## Summary
- mount user's git configuration and SSH keys by default
- set default git user in devcontainer post-create
- document how to share your Git config

## Testing
- `./gradlew build` *(fails: no main manifest attribute)*
