### PR TITLE
Set explicit ForgeGradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
-    id 'net.minecraftforge.gradle' version '6.+'
+    // ForgeGradle version explicitly pinned for Forge 1.21.8 projects
+    // Update when Forge recommends a newer plugin release
+    id 'net.minecraftforge.gradle' version '6.0.36'
 }
 group = 'com.banzaicode'
 version = '1.0.0'


### PR DESCRIPTION
## Summary
- pin ForgeGradle plugin to version 6.0.36
- add comments explaining version choice

## Testing
- `./gradlew tasks --no-daemon`
