### PR TITLE
Update docs for version consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Para más detalles sobre el entorno y la compilación revisa la [guía completa]
 
 - Java 21
 - Gradle 8.4
-- Servidor de Minecraft 1.21.8 con Forge 58.0.0
+- Servidor de Minecraft 1.21.8 con Forge 58.0.0 o superior
 
 ## ¿Cómo clonar el repositorio?
 
@@ -40,7 +40,7 @@ Para realizar pruebas locales rápidas, usa el DevContainer: compila con el coma
 
 ## Uso en servidor propio
 
-Este mod requiere un servidor de Minecraft 1.21.8 con Forge 58.0.0 y Java 21.
+Este mod requiere un servidor de Minecraft 1.21.8 con Forge 58.0.0 o superior y Java 21.
 
 1. Descarga la versión del servidor de Forge para 1.21.8 (por ejemplo `forge-1.21.8-58.0.0`).
 2. Copia el `.jar` generado en `dist/` dentro de la carpeta `mods/` del servidor.
@@ -52,7 +52,7 @@ java -jar forge-1.21.8-58.0.0.jar nogui
 
 ## Solución de problemas
 
-- **Versión incorrecta de Forge**: asegúrate de usar la versión 1.21.8 de Forge (58.0.0). Si utilizas otra versión el mod puede no cargar. Descarga la versión adecuada desde el sitio oficial de Forge e instálala nuevamente.
+- **Versión incorrecta de Forge**: asegúrate de usar la versión 1.21.8 de Forge (mínimo 58.0.0). Si utilizas otra versión el mod puede no cargar. Descarga la versión adecuada desde el sitio oficial de Forge e instálala nuevamente.
 - **No estás usando Java 21**: la compilación y ejecución requieren Java 21. Instala JDK 21 o abre el proyecto en el DevContainer donde ya está incluido.
 - **Gradle ejecutado fuera del DevContainer**: si corres `./gradlew` fuera del contenedor puedes tener dependencias faltantes o la versión de Java incorrecta. Abre el repositorio con **Reopen in Container** y ejecuta los comandos allí.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Esta sección del tutorial explica cómo configurar el entorno, compilar el mod 
 
 1. Instala [Visual Studio Code](https://code.visualstudio.com/).
 2. Abre este repositorio en VS Code y elige **Reopen in Container**.
-3. El contenedor se construirá con Java 21 y Gradle listos para usar.
+3. El contenedor se construirá con **Java 21** y **Gradle 8.4** listos para usar.
 
 Cuando el contenedor esté listo verás la carpeta del proyecto abierta con todas las dependencias resueltas.
 
@@ -22,7 +22,7 @@ Al finalizar se generará un archivo `.jar` en la carpeta `dist/`. Este es el mo
 
 ## 3. Instalar en Minecraft
 
-1. Descarga e instala Forge 1.21.8 en tu cliente o servidor.
+1. Descarga e instala Forge 1.21.8 (versión mínima 58.0.0) en tu cliente o servidor.
 2. Copia el `.jar` que está en `dist/` dentro de la carpeta `mods/` de tu instalación de Minecraft.
 3. Inicia el juego o el servidor y el bloque **Soulbound** estará disponible.
 


### PR DESCRIPTION
## Summary
- clarify Gradle and Forge versions in main documentation
- match Java and Gradle versions in tutorial

## Testing
- `./gradlew --version`
- `./gradlew build`
